### PR TITLE
Add Lazy support

### DIFF
--- a/serket/nn/blur.py
+++ b/serket/nn/blur.py
@@ -10,10 +10,11 @@ import jax.numpy as jnp
 import pytreeclass as pytc
 
 from .convolution import DepthwiseConv2D
+from .utils import _TRACER_ERROR_MSG
 
 
 @pytc.treeclass
-class _AvgBlur2D:
+class AvgBlur2D:
     conv1: DepthwiseConv2D = pytc.nondiff_field(repr=False)
     conv2: DepthwiseConv2D = pytc.nondiff_field(repr=False)
 
@@ -23,6 +24,16 @@ class _AvgBlur2D:
             in_features: number of input channels
             kernel_size: size of the convolving kernel
         """
+        if in_features is None:
+            for field_item in dataclasses.fields(self):
+                setattr(self, field_item.name, None)
+            self._partial_init = ft.partial(
+                AvgBlur2D.__init__,
+                self=self,
+                kernel_size=kernel_size,
+            )
+            return
+
         if not isinstance(in_features, int) or in_features <= 0:
             raise ValueError(
                 f"Expected `in_features` to be a positive integer, got {in_features}"
@@ -55,36 +66,18 @@ class _AvgBlur2D:
         self.conv2 = self.conv2.at["weight"].set(jnp.moveaxis(w, 2, 3))  # transpose
 
     def __call__(self, x, **kwargs) -> jnp.ndarray:
+        if hasattr(self, "_partial_init"):
+            if isinstance(x, jax.core.Tracer):
+                raise ValueError(_TRACER_ERROR_MSG)
+            self._partial_init(in_features=x.shape[0])
+            object.__delattr__(self, "_partial_init")
+
         assert x.ndim == 3, "`Input` must be 3D."
         return self.conv2(self.conv1(x))
 
 
 @pytc.treeclass
-class AvgBlur2D(_AvgBlur2D):
-    def __init__(self, in_features, kernel_size):
-        if in_features is None:
-            for field_item in dataclasses.fields(self):
-                setattr(self, field_item.name, None)
-
-            self._partial_init = ft.partial(
-                super().__init__,
-                kernel_size=kernel_size,
-            )
-        else:
-            super().__init__(
-                in_features=in_features,
-                kernel_size=kernel_size,
-            )
-
-    def __call__(self, x, **kwargs):
-        if hasattr(self, "_partial_init"):
-            self._partial_init(in_features=x.shape[0])
-            object.__delattr__(self, "_partial_init")
-        return super().__call__(x, **kwargs)
-
-
-@pytc.treeclass
-class _GaussianBlur2D:
+class GaussianBlur2D:
     in_features: int = pytc.nondiff_field()
     kernel_size: int = pytc.nondiff_field()
     sigma: float = pytc.nondiff_field()
@@ -107,6 +100,17 @@ class _GaussianBlur2D:
             kernel_size: kernel size
             sigma: sigma. Defaults to 1.
         """
+        if in_features is None:
+            for field_item in dataclasses.fields(self):
+                setattr(self, field_item.name, None)
+            self._partial_init = ft.partial(
+                GaussianBlur2D.__init__,
+                self=self,
+                kernel_size=kernel_size,
+                sigma=sigma,
+            )
+            return
+
         if not isinstance(in_features, int) or in_features <= 0:
             raise ValueError(
                 f"Expected `in_features` to be a positive integer, got {in_features}"
@@ -165,29 +169,11 @@ class _GaussianBlur2D:
         #     raise ValueError(f"Unknown implementation {implementation}")
 
     def __call__(self, x, **kwargs) -> jnp.ndarray:
-        assert x.ndim == 3, "`Input` must be 3D."
-        return self.conv1(self.conv2(x))
-
-
-@pytc.treeclass
-class GaussianBlur2D(_GaussianBlur2D):
-    def __init__(self, in_features, kernel_size, *, sigma=1.0):
-        if in_features is None:
-            for field_item in dataclasses.fields(self):
-                setattr(self, field_item.name, None)
-
-            self._partial_init = ft.partial(
-                super().__init__, kernel_size=kernel_size, sigma=sigma
-            )
-        else:
-            super().__init__(
-                in_features=in_features,
-                kernel_size=kernel_size,
-                sigma=sigma,
-            )
-
-    def __call__(self, x, **kwargs):
         if hasattr(self, "_partial_init"):
+            if isinstance(x, jax.core.Tracer):
+                raise ValueError(_TRACER_ERROR_MSG)
             self._partial_init(in_features=x.shape[0])
             object.__delattr__(self, "_partial_init")
-        return super().__call__(x, **kwargs)
+
+        assert x.ndim == 3, "`Input` must be 3D."
+        return self.conv1(self.conv2(x))

--- a/serket/nn/convolution.py
+++ b/serket/nn/convolution.py
@@ -1061,7 +1061,7 @@ class ConvNDLocal:
         if hasattr(self, "_partial_init"):
             if isinstance(x, jax.core.Tracer):
                 raise ValueError(_TRACER_ERROR_MSG)
-            self._partial_init(in_features=x.shape[0])
+            self._partial_init(in_features=x.shape[0], in_size=x.shape[1:])
             object.__delattr__(self, "_partial_init")
 
         y = jax.lax.conv_general_dilated_local(

--- a/serket/nn/utils.py
+++ b/serket/nn/utils.py
@@ -187,3 +187,11 @@ def _create_fields_from_mapping(items: dict[str, Any]) -> dict:
         object.__setattr__(field_item, "type", type(item))
         return_map[field_name] = field_item
     return return_map
+
+
+_TRACER_ERROR_MSG = (
+    "Using Tracers as input to an unintialized layer is not supported. "
+    "Call the layer with a non Tracer input first.\n"
+    "This error can occur if a layer is jitted before being initialized. "
+    "or a Tracer is passed to a layer that is not jitted."
+)

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
@@ -60,3 +61,11 @@ def test_GaussBlur2D():
 def test_lazy_blur():
     layer = GaussianBlur2D(in_features=None, kernel_size=3, sigma=1.0)
     assert layer(jnp.ones([10, 5, 5])).shape == (10, 5, 5)
+
+    with pytest.raises(ValueError):
+        jax.jit(GaussianBlur2D(in_features=None, kernel_size=3, sigma=1.0))(
+            jnp.ones([10, 5, 5])
+        )
+
+    with pytest.raises(ValueError):
+        jax.jit(AvgBlur2D(in_features=None, kernel_size=3))(jnp.ones([10, 5, 5]))

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -1124,3 +1124,39 @@ def test_lazy_conv():
 
     layer = SeparableConv2D(None, 1, 3)
     assert layer(jnp.ones([10, 3, 3])).shape == (1, 3, 3)
+
+    with pytest.raises(ValueError):
+        jax.jit(Conv1D(None, 1, 3))(jnp.ones([10, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(Conv2D(None, 1, 3))(jnp.ones([10, 3, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(Conv3D(None, 1, 3))(jnp.ones([10, 3, 3, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(Conv1DTranspose(None, 1, 3))(jnp.ones([10, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(Conv2DTranspose(None, 1, 3))(jnp.ones([10, 3, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(Conv3DTranspose(None, 1, 3))(jnp.ones([10, 3, 3, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(DepthwiseConv1D(None, 3))(jnp.ones([10, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(DepthwiseConv2D(None, 3))(jnp.ones([10, 3, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(Conv1DLocal(None, 1, 3, in_size=(3,)))(jnp.ones([10, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(Conv2DLocal(None, 1, 3, in_size=(3, 3)))(jnp.ones([10, 3, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(SeparableConv1D(None, 1, 3))(jnp.ones([10, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(SeparableConv2D(None, 1, 3))(jnp.ones([10, 3, 3]))

--- a/tests/test_convolution_scan.py
+++ b/tests/test_convolution_scan.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import numpy.testing as npt
+import pytest
 
 from serket.nn import ConvScan1D, ConvScan2D, ConvScan3D
 
@@ -85,3 +87,12 @@ def test_lazy_convscan():
     layer = ConvScan3D(None, 1, 3)
     assert layer.weight is None
     assert layer(jnp.ones([10, 3, 3, 3])).shape == (1, 3, 3, 3)
+
+    with pytest.raises(ValueError):
+        jax.jit(ConvScan1D(None, 1, 3))(jnp.ones([10, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(ConvScan2D(None, 1, 3))(jnp.ones([10, 3, 3]))
+
+    with pytest.raises(ValueError):
+        jax.jit(ConvScan3D(None, 1, 3))(jnp.ones([10, 3, 3, 3]))

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1,6 +1,7 @@
 import jax
 import jax.numpy as jnp
 import numpy.testing as npt
+import pytest
 import pytreeclass as pytc
 
 from serket.nn import FNN, Bilinear, Identity, Linear
@@ -78,3 +79,11 @@ def test_lazy():
     layer = Bilinear(None, None, 1)
     assert layer.weight is None
     assert layer(jnp.ones([10, 2]), jnp.ones([10, 3])).shape == (10, 1)
+
+    with pytest.raises(ValueError):
+        layer = jax.jit(Linear(None, 1))
+        layer(jnp.ones([10, 2]))
+
+    with pytest.raises(ValueError):
+        layer = jax.jit(Bilinear(None, None, 1))
+        layer(jnp.ones([10, 2]), jnp.ones([10, 3]))

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
@@ -203,3 +204,7 @@ def test_lazy_normalization():
     layer = GroupNorm(None, groups=1)
     assert layer.groups is None
     assert layer(jnp.ones([1, 2, 3, 4])).shape == (1, 2, 3, 4)
+
+    with pytest.raises(ValueError):
+        layer = jax.jit(GroupNorm(None, groups=1))
+        layer(jnp.ones([1, 2, 3, 4]))


### PR DESCRIPTION
This pull request closes #5 

## What has changed
use `None` instead of `in_features` to infer the value from the input shape.

Example:
```python

model = sk.nn.Conv2D(None,1,3)
model(jnp.ones([10,3,3]).shape  # (1,3,3)

```