### PR TITLE
Add Recurrent layers

### DIFF
--- a/serket/nn/recurrent.py
+++ b/serket/nn/recurrent.py
@@ -1,120 +1,578 @@
 from __future__ import annotations
 
+# import dataclasses
+# import functools as ft
 from typing import Callable
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytreeclass as pytc
-from jax.nn import sigmoid as σ
 
 from serket.nn import Linear
+from serket.nn.convolution import ConvND
+
+# from serket.nn.utils import _TRACER_ERROR_MSG
+
+_act_func_map = {
+    "tanh": jax.nn.tanh,
+    "relu": jax.nn.relu,
+    "sigmoid": jax.nn.sigmoid,
+    "hard_sigmoid": jax.nn.hard_sigmoid,
+    None: lambda x: x,
+}
+
+
+# --------------------------------------------------- RNN ------------------------------------------------------------ #
 
 
 @pytc.treeclass
 class RNNState:
     hidden_state: jnp.ndarray
-
-
-@pytc.treeclass
-class RNNCell:
-    in_features: int = pytc.nondiff_field()
-    hidden_features: int = pytc.nondiff_field()
-
-    in_and_hidden_to_hidden: Linear
-
-    def __init__(
-        self,
-        in_features: int,
-        hidden_features: int,
-        *,
-        weight_init_func: str | Callable = "he_norma",
-        bias_init_func: str | Callable | None = "zeros",
-        key: jr.PRNGKey = jr.PRNGKey(0),
-    ):
-        """Vanilla RNN cell that defines the update rule for the hidden state
-        See:
-            https://pytorch.org/docs/stable/generated/torch.nn.RNN.html
-
-        Args:
-            in_features: input features
-            hidden_features: hidden features
-            weight_init_func: weight initialization function . Defaults to "he_normal".
-            bias_init_func: bias initialization function . Defaults to zeros.
-            key: Random key for weight and bias initialization. Defaults to jr.PRNGKey(0).
-        """
-
-        k1, k2 = jr.split(key, 2)
-        self.in_features = in_features
-        self.hidden_features = hidden_features
-        self.in_and_hidden_to_hidden = Linear(
-            in_features=in_features + hidden_features,
-            out_features=hidden_features,
-            weight_init_func=weight_init_func,
-            bias_init_func=bias_init_func,
-            key=key,
-        )
-
-    def __call__(
-        self, x: jnp.ndarray, state: RNNState, **kwargs
-    ) -> tuple[jnp.ndarray, jnp.ndarray]:
-        h = state.hidden_state
-        h = jnp.tanh(self.in_and_hidden_to_hidden(jnp.concatenate([x, h], axis=-1)))
-        return h, h
-
-
-@pytc.treeclass
-class LSTMState:
-    hidden_state: jnp.ndarray
     cell_state: jnp.ndarray
 
 
 @pytc.treeclass
-class LSTMCell:
-    in_features: int = pytc.nondiff_field()
-    hidden_features: int = pytc.nondiff_field()
-    in_and_hidden_to_hidden: Linear
+class RNNCell:
+    pass
+
+
+def _init_rnn_state(hidden_features: int) -> RNNState:
+    return RNNState(jnp.zeros([1, hidden_features]), jnp.zeros([1, hidden_features]))
+
+
+def _init_spatial_rnn_state(
+    hidden_features: int, spatial_dim: tuple[int, ...]
+) -> RNNState:
+    shape = (hidden_features, *spatial_dim)
+    return RNNState(jnp.zeros(shape), jnp.zeros(shape))
+
+
+@pytc.treeclass
+class SimpleRNNCell(RNNCell):
+    in_to_hidden: Linear
+    hidden_to_hidden: Linear
 
     def __init__(
         self,
         in_features: int,
         hidden_features: int,
         *,
-        weight_init_func: str | Callable = "he_normal",
+        weight_init_func: str | Callable = "glorot_uniform",
         bias_init_func: str | Callable | None = "zeros",
+        recurrent_weight_init_func: str | Callable = "orthogonal",
+        act_func: str | None = "tanh",
         key: jr.PRNGKey = jr.PRNGKey(0),
     ):
-        """Defines the update rule for the hidden state and the cell state
-
+        """Vanilla RNN cell that defines the update rule for the hidden state
         See:
-            https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html
-            https://github.com/deepmind/dm-haiku/blob/main/haiku/_src/recurrent.py
+            https://www.tensorflow.org/api_docs/python/tf/keras/layers/SimpleRNNCell
 
         Args:
-            in_features: input features
-            hidden_features: hidden features
-            weight_init_func: weight initialization function . Defaults to "he_normal".
-            bias_init_func: bias initialization function . Defaults to zeros.
-            key: Random key for weight and bias initialization. Defaults to jr.PRNGKey(0).
-        """
-        self.hidden_features = hidden_features
-        self.in_features = in_features
+            in_features: the number of input features
+            hidden_features: the number of hidden features
+            weight_init_func: the function to use to initialize the weights
+            bias_init_func: the function to use to initialize the bias
+            recurrent_weight_init_func: the function to use to initialize the recurrent weights
+            act_func: the activation function to use for the hidden state update
+            key: the key to use to initialize the weights
 
-        self.in_and_hidden_to_hidden = Linear(
-            in_features=in_features + hidden_features,
-            out_features=4 * hidden_features,
+        Example:
+            >>> cell = SimpleRNNCell(10, 20)
+            >>> cell(jnp.ones([10]), RNNState(jnp.zeros([20]), jnp.zeros([20])))
+        """
+        # if in_features is None:
+        #     for field_item in dataclasses.fields(self):
+        #         # set all fields to None to mark the class as uninitialized
+        #         # to the user and to avoid errors
+        #         setattr(self, field_item.name, None)
+
+        #     self._partial_init = ft.partial(
+        #         SimpleRNNCell.__init__,
+        #         self=self,
+        #         hidden_features=hidden_features,
+        #         weight_init_func=weight_init_func,
+        #         bias_init_func=bias_init_func,
+        #         recurrent_weight_init_func=recurrent_weight_init_func,
+        #         act_func=act_func,
+        #         key=key,
+        #     )
+
+        #     return
+
+        # if hasattr(self, "_partial_init"):
+        #     delattr(self, "_partial_init")
+
+        k1, k2 = jr.split(key, 2)
+
+        if not isinstance(in_features, int) or in_features < 1:
+            raise ValueError(
+                f"Expected in_features to be a positive integer, got {in_features}"
+            )
+
+        if not isinstance(hidden_features, int) or hidden_features < 1:
+            raise ValueError(
+                f"Expected hidden_features to be a positive integer, got {hidden_features}"
+            )
+
+        self.act_func = _act_func_map[act_func]
+
+        self.in_features = in_features
+        self.hidden_features = hidden_features
+
+        self.in_to_hidden = Linear(
+            in_features,
+            hidden_features,
             weight_init_func=weight_init_func,
             bias_init_func=bias_init_func,
-            key=key,
+            key=k1,
         )
 
-    def __call__(
-        self, x: jnp.ndarray, state: LSTMState, **kwargs
-    ) -> tuple[tuple[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
+        self.hidden_to_hidden = Linear(
+            hidden_features,
+            hidden_features,
+            weight_init_func=recurrent_weight_init_func,
+            bias_init_func=None,
+            key=k2,
+        )
+
+    def __call__(self, x: jnp.ndarray, state: RNNState, **kwargs) -> RNNState:
+        # if hasattr(self, "_partial_init"):
+        #     if isinstance(x, jax.core.Tracer):
+        #         raise ValueError(_TRACER_ERROR_MSG(self.__class__.__name__))
+        #     self._partial_init(in_features=x.shape[0])
+
+        h = state.hidden_state
+        h = self.act_func(self.in_to_hidden(x) + self.hidden_to_hidden(h))
+        return RNNState(h, h * 0.0)
+
+
+@pytc.treeclass
+class LSTMCell(RNNCell):
+    in_to_hidden: Linear
+    hidden_to_hidden: Linear
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        *,
+        weight_init_func: str | Callable = "glorot_uniform",
+        bias_init_func: str | Callable | None = "zeros",
+        recurrent_weight_init_func: str | Callable = "orthogonal",
+        act_func: str | None = "tanh",
+        recurrent_act_func: str | None = "sigmoid",
+        key: jr.PRNGKey = jr.PRNGKey(0),
+    ):
+        """LSTM cell that defines the update rule for the hidden state and cell state
+        Args:
+            in_features: the number of input features
+            hidden_features: the number of hidden features
+            weight_init_func: the function to use to initialize the weights
+            bias_init_func: the function to use to initialize the bias
+            recurrent_weight_init_func: the function to use to initialize the recurrent weights
+            act_func: the activation function to use for the hidden state update
+            recurrent_act_func: the activation function to use for the cell state update
+            key: the key to use to initialize the weights
+
+        See:
+            https://www.tensorflow.org/api_docs/python/tf/keras/layers/LSTMCell
+            https://github.com/deepmind/dm-haiku/blob/main/haiku/_src/recurrent.py
+        """
+        # if in_features is None:
+        #     for field_item in dataclasses.fields(self):
+        #         # set all fields to None to mark the class as uninitialized
+        #         # to the user and to avoid errors
+        #         setattr(self, field_item.name, None)
+
+        #     self._partial_init = ft.partial(
+        #         LSTMCell.__init__,
+        #         self=self,
+        #         hidden_features=hidden_features,
+        #         weight_init_func=weight_init_func,
+        #         bias_init_func=bias_init_func,
+        #         recurrent_weight_init_func=recurrent_weight_init_func,
+        #         act_func=act_func,
+        #         recurrent_act_func=recurrent_act_func,
+        #         key=key,
+        #     )
+
+        #     return
+
+        # if hasattr(self, "_partial_init"):
+        #     delattr(self, "_partial_init")
+
+        k1, k2 = jr.split(key, 2)
+
+        if not isinstance(in_features, int) or in_features < 1:
+            raise ValueError(
+                f"Expected in_features to be a positive integer, got {in_features}"
+            )
+
+        if not isinstance(hidden_features, int) or hidden_features < 1:
+            raise ValueError(
+                f"Expected hidden_features to be a positive integer, got {hidden_features}"
+            )
+
+        self.act_func = _act_func_map[act_func]
+        self.recurrent_act_func = _act_func_map[recurrent_act_func]
+
+        self.in_features = in_features
+        self.hidden_features = hidden_features
+
+        self.in_to_hidden = Linear(
+            in_features,
+            hidden_features * 4,
+            weight_init_func=weight_init_func,
+            bias_init_func=bias_init_func,
+            key=k1,
+        )
+
+        self.hidden_to_hidden = Linear(
+            hidden_features,
+            hidden_features * 4,
+            weight_init_func=recurrent_weight_init_func,
+            bias_init_func=None,
+            key=k2,
+        )
+
+    def __call__(self, x: jnp.ndarray, state: RNNState, **kwargs) -> RNNState:
+        # if hasattr(self, "_partial_init"):
+        #     if isinstance(x, jax.core.Tracer):
+        #         raise ValueError(_TRACER_ERROR_MSG(self.__class__.__name__))
+        #     self._partial_init(in_features=x.shape[0])
 
         h, c = state.hidden_state, state.cell_state
-        ifgo = self.in_and_hidden_to_hidden(jnp.concatenate([x, h], axis=-1))
-        i, f, g, o = jnp.split(ifgo, 4, axis=-1)
-        i, f, g, o = σ(i), σ(f), jnp.tanh(g), σ(o)
+
+        h = self.in_to_hidden(x) + self.hidden_to_hidden(h)
+        i, f, g, o = jnp.split(h, 4, axis=-1)
+        i = self.recurrent_act_func(i)
+        f = self.recurrent_act_func(f)
+        g = self.act_func(g)
+        o = self.recurrent_act_func(o)
         c = f * c + i * g
-        h = o * jnp.tanh(c)
-        return LSTMState(h, c)
+        h = o * self.act_func(c)
+        return RNNState(hidden_state=h, cell_state=c)
+
+
+# ------------------------------------------------- Spatial RNN ------------------------------------------------------ #
+@pytc.treeclass
+class SpatialRNNCell(RNNCell):
+    pass
+
+
+@pytc.treeclass
+class ConvLSTMNDCell(SpatialRNNCell):
+    in_to_hidden: ConvND
+    hidden_to_hidden: ConvND
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        kernel_size: int | tuple[int, ...],
+        *,
+        strides: int | tuple[int, ...] = 1,
+        padding: str | tuple[int, ...] | tuple[tuple[int, int], ...] = "SAME",
+        input_dilation: int | tuple[int, ...] = 1,
+        kernel_dilation: int | tuple[int, ...] = 1,
+        weight_init_func: str | Callable = "glorot_uniform",
+        bias_init_func: str | Callable | None = "zeros",
+        recurrent_weight_init_func: str | Callable = "orthogonal",
+        act_func: str | None = "tanh",
+        recurrent_act_func: str | None = "hard_sigmoid",
+        key: jr.PRNGKey = jr.PRNGKey(0),
+        ndim: int = 2,
+    ):
+        """Convolution LSTM cell that defines the update rule for the hidden state and cell state
+        Args:
+            in_features: Number of input features
+            out_features: Number of output features
+            kernel_size: Size of the convolutional kernel
+            strides: Stride of the convolution
+            padding: Padding of the convolution
+            input_dilation: Dilation of the input
+            kernel_dilation: Dilation of the convolutional kernel
+            weight_init_func: Weight initialization function
+            bias_init_func: Bias initialization function
+            recurrent_weight_init_func: Recurrent weight initialization function
+            act_func: Activation function
+            recurrent_act_func: Recurrent activation function
+            key: PRNG key
+            ndim: Number of spatial dimensions
+
+        See: https://www.tensorflow.org/api_docs/python/tf/keras/layers/ConvLSTM1D
+        """
+        # if in_features is None:
+        #     for field_item in dataclasses.fields(self):
+        #         # set all fields to None to mark the class as uninitialized
+        #         # to the user and to avoid errors
+        #         setattr(self, field_item.name, None)
+
+        #     self._partial_init = ft.partial(
+        #         ConvLSTMNDCell.__init__,
+        #         self=self,
+        #         out_features=out_features,
+        #         kernel_size=kernel_size,
+        #         strides=strides,
+        #         padding=padding,
+        #         input_dilation=input_dilation,
+        #         kernel_dilation=kernel_dilation,
+        #         weight_init_func=weight_init_func,
+        #         bias_init_func=bias_init_func,
+        #         recurrent_weight_init_func=recurrent_weight_init_func,
+        #         act_func=act_func,
+        #         recurrent_act_func=recurrent_act_func,
+        #         key=key,
+        #         ndim=ndim,
+        #     )
+
+        #     return
+
+        # if hasattr(self, "_partial_init"):
+        #     delattr(self, "_partial_init")
+
+        k1, k2 = jr.split(key, 2)
+
+        if not isinstance(in_features, int) or in_features < 1:
+            raise ValueError(
+                f"Expected in_features to be a positive integer, got {in_features}"
+            )
+
+        if not isinstance(out_features, int) or out_features < 1:
+            raise ValueError(
+                f"Expected out_features to be a positive integer, got {out_features}"
+            )
+
+        self.act_func = _act_func_map[act_func]
+        self.recurrent_act_func = _act_func_map[recurrent_act_func]
+        self.in_features = in_features
+        self.out_features = out_features
+        self.hidden_features = out_features
+        self.ndim = ndim
+
+        self.in_to_hidden = ConvND(
+            in_features,
+            out_features * 4,
+            kernel_size,
+            strides=strides,
+            padding=padding,
+            input_dilation=input_dilation,
+            kernel_dilation=kernel_dilation,
+            weight_init_func=weight_init_func,
+            bias_init_func=bias_init_func,
+            key=k1,
+            ndim=ndim,
+        )
+
+        self.hidden_to_hidden = ConvND(
+            out_features,
+            out_features * 4,
+            kernel_size,
+            strides=strides,
+            padding=padding,
+            input_dilation=input_dilation,
+            kernel_dilation=kernel_dilation,
+            weight_init_func=recurrent_weight_init_func,
+            bias_init_func=None,
+            key=k2,
+            ndim=ndim,
+        )
+
+    def __call__(self, x: jnp.ndarray, state: RNNState, **kwargs) -> RNNState:
+        # if hasattr(self, "_partial_init"):
+        #     if isinstance(x, jax.core.Tracer):
+        #         raise ValueError(_TRACER_ERROR_MSG(self.__class__.__name__))
+        #     self._partial_init(in_features=x.shape[0])
+
+        h, c = state.hidden_state, state.cell_state
+
+        h = self.in_to_hidden(x) + self.hidden_to_hidden(h)
+        i, f, g, o = jnp.split(h, 4, axis=0)
+        i = self.recurrent_act_func(i)
+        f = self.recurrent_act_func(f)
+        g = self.act_func(g)
+        o = self.recurrent_act_func(o)
+        c = f * c + i * g
+        h = o * self.act_func(c)
+        return RNNState(hidden_state=h, cell_state=c)
+
+
+@pytc.treeclass
+class ConvLSTM1DCell(ConvLSTMNDCell):
+    def __init__(
+        self,
+        in_features: int | None,
+        out_features: int,
+        kernel_size: int,
+        strides: int = 1,
+        padding: str = "same",
+        input_dilation: int = 1,
+        kernel_dilation: int = 1,
+        weight_init_func: str | Callable = "glorot_uniform",
+        bias_init_func: str | Callable | None = "zeros",
+        recurrent_weight_init_func: str | Callable = "orthogonal",
+        act_func: str | None = "tanh",
+        recurrent_act_func: str | None = "sigmoid",
+        key: jr.PRNGKey = jr.PRNGKey(0),
+    ):
+        super().__init__(
+            in_features=in_features,
+            out_features=out_features,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            input_dilation=input_dilation,
+            kernel_dilation=kernel_dilation,
+            weight_init_func=weight_init_func,
+            bias_init_func=bias_init_func,
+            recurrent_weight_init_func=recurrent_weight_init_func,
+            act_func=act_func,
+            recurrent_act_func=recurrent_act_func,
+            key=key,
+            ndim=1,
+        )
+
+
+@pytc.treeclass
+class ConvLSTM2DCell(ConvLSTMNDCell):
+    def __init__(
+        self,
+        in_features: int | None,
+        out_features: int,
+        kernel_size: int | tuple[int, int],
+        strides: int | tuple[int, int] = 1,
+        padding: str = "same",
+        input_dilation: int | tuple[int, int] = 1,
+        kernel_dilation: int | tuple[int, int] = 1,
+        weight_init_func: str | Callable = "glorot_uniform",
+        bias_init_func: str | Callable | None = "zeros",
+        recurrent_weight_init_func: str | Callable = "orthogonal",
+        act_func: str | None = "tanh",
+        recurrent_act_func: str | None = "sigmoid",
+        key: jr.PRNGKey = jr.PRNGKey(0),
+    ):
+        super().__init__(
+            in_features=in_features,
+            out_features=out_features,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            input_dilation=input_dilation,
+            kernel_dilation=kernel_dilation,
+            weight_init_func=weight_init_func,
+            bias_init_func=bias_init_func,
+            recurrent_weight_init_func=recurrent_weight_init_func,
+            act_func=act_func,
+            recurrent_act_func=recurrent_act_func,
+            key=key,
+            ndim=2,
+        )
+
+
+@pytc.treeclass
+class ConvLSTM3DCell(ConvLSTMNDCell):
+    def __init__(
+        self,
+        in_features: int | None,
+        out_features: int,
+        kernel_size: int | tuple[int, int, int],
+        strides: int | tuple[int, int, int] = 1,
+        padding: str = "same",
+        input_dilation: int | tuple[int, int, int] = 1,
+        kernel_dilation: int | tuple[int, int, int] = 1,
+        weight_init_func: str | Callable = "glorot_uniform",
+        bias_init_func: str | Callable | None = "zeros",
+        recurrent_weight_init_func: str | Callable = "orthogonal",
+        act_func: str | None = "tanh",
+        recurrent_act_func: str | None = "sigmoid",
+        key: jr.PRNGKey = jr.PRNGKey(0),
+    ):
+        super().__init__(
+            in_features=in_features,
+            out_features=out_features,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            input_dilation=input_dilation,
+            kernel_dilation=kernel_dilation,
+            weight_init_func=weight_init_func,
+            bias_init_func=bias_init_func,
+            recurrent_weight_init_func=recurrent_weight_init_func,
+            act_func=act_func,
+            recurrent_act_func=recurrent_act_func,
+            key=key,
+            ndim=3,
+        )
+
+
+# ------------------------------------------------- Scan layer ------------------------------------------------------ #
+
+
+@pytc.treeclass
+class ScanRNNCell:
+    cell: RNNCell | SpatialRNNCell
+
+    def __init__(
+        self,
+        cell: RNNCell | SpatialRNNCell,
+        *,
+        reverse: bool = False,
+        return_sequences: bool = False,
+    ):
+        """Scans a RNN cell over a sequence.
+
+        Args:
+            cell: the RNN cell to use
+            reverse: whether to scan the sequence in reverse
+            return_sequences: whether to return the hidden state for each timestep
+
+        Example:
+            >>> cell = SimpleRNNCell(10, 20) # 10-dimensional input, 20-dimensional hidden state
+            >>> rnn = ScanRNNCell(cell)
+            >>> x = jnp.ones((5, 10)) # 5 timesteps, 10 features
+            >>> result = rnn(x, state)
+        """
+        if not isinstance(cell, RNNCell):
+            raise ValueError("cell must be instance of RNNCell")
+
+        self.cell = cell
+        self.reverse = reverse
+        self.return_sequences = return_sequences
+
+    def __call__(
+        self, x: jnp.ndarray, state: RNNState = None, **kwargs
+    ) -> jnp.ndarray | tuple[jnp.ndarray, RNNState]:
+
+        if isinstance(self.cell, SpatialRNNCell):
+            # (time steps, in_features, *spatial_dims)
+            msg = f"Expected x to have {self.cell.ndim + 2}"
+            msg += f"dimensions corresponds to (timesteps, in_features, *spatial_dims), got {x.ndim}"
+            assert x.ndim == (self.cell.ndim + 2), msg
+        else:
+            # (time steps, in_features)
+            msg = f"Expected x to have 2 dimensions corresponds to (timesteps, in_features), got {x.ndim}"
+            assert x.ndim == 2, msg
+
+        if state is None:
+            # initialize the hidden state
+            if isinstance(self.cell, SpatialRNNCell):
+                state = _init_spatial_rnn_state(self.cell.out_features, x.shape[2:])
+            else:
+                state = _init_rnn_state(self.cell.hidden_features)
+
+        if not isinstance(state, RNNState):
+            raise ValueError("state must be an RNNState")
+
+        if self.return_sequences:
+            # accumulate the hidden state for each timestep
+            def scan_func(carry, x):
+                state = self.cell(x, state=carry)
+                return state, state
+
+            return jax.lax.scan(scan_func, state, x, reverse=self.reverse)
+
+        # do not accumulate the hidden state for each timestep
+        scan_func = lambda carry, x: (self.cell(x, state=carry), None)
+        output, _ = jax.lax.scan(scan_func, state, x, reverse=self.reverse)
+        return output.hidden_state

--- a/serket/nn/utils.py
+++ b/serket/nn/utils.py
@@ -5,6 +5,7 @@ import functools as ft
 from types import FunctionType
 from typing import Any, Callable, Sequence
 
+import jax
 import jax.nn.initializers as ji
 import jax.numpy as jnp
 import jax.tree_util as jtu
@@ -34,19 +35,28 @@ def _rename_func(func: Callable, name: str) -> Callable:
     return func
 
 
+_act_func_map = {
+    "tanh": jax.nn.tanh,
+    "relu": jax.nn.relu,
+    "sigmoid": jax.nn.sigmoid,
+    "hard_sigmoid": jax.nn.hard_sigmoid,
+    None: lambda x: x,
+}
+
 _init_func_dict = {
-    "he_normal": _rename_func(ji.he_normal(), "he_normal"),
-    "he_uniform": _rename_func(ji.he_uniform(), "he_uniform"),
-    "glorot_normal": _rename_func(ji.glorot_normal(), "glorot_normal"),
-    "glorot_uniform": _rename_func(ji.glorot_uniform(), "glorot_uniform"),
-    "lecun_normal": _rename_func(ji.lecun_normal(), "lecun_normal"),
-    "lecun_uniform": _rename_func(ji.lecun_uniform(), "lecun_uniform"),
-    "normal": _rename_func(ji.normal(), "normal"),
-    "uniform": _rename_func(ji.uniform(), "uniform"),
-    "ones": ji.ones,
-    "zeros": ji.zeros,
-    "xavier_normal": _rename_func(ji.xavier_normal(), "xavier_normal"),
-    "xavier_uniform": _rename_func(ji.xavier_uniform(), "xavier_uniform"),
+    "he_normal": _rename_func(ji.he_normal(), "he_normal_init"),
+    "he_uniform": _rename_func(ji.he_uniform(), "he_uniform_init"),
+    "glorot_normal": _rename_func(ji.glorot_normal(), "glorot_normal_init"),
+    "glorot_uniform": _rename_func(ji.glorot_uniform(), "glorot_uniform_init"),
+    "lecun_normal": _rename_func(ji.lecun_normal(), "lecun_normal_init"),
+    "lecun_uniform": _rename_func(ji.lecun_uniform(), "lecun_uniform_init"),
+    "normal": _rename_func(ji.normal(), "normal_init"),
+    "uniform": _rename_func(ji.uniform(), "uniform_init"),
+    "ones": _rename_func(ji.ones, "ones_init"),
+    "zeros": _rename_func(ji.zeros, "zeros_init"),
+    "xavier_normal": _rename_func(ji.xavier_normal(), "xavier_normal_init"),
+    "xavier_uniform": _rename_func(ji.xavier_uniform(), "xavier_uniform_init"),
+    "orthogonal": _rename_func(ji.orthogonal(), "orthogonal_init"),
 }
 
 

--- a/tests/test_recurrent.py
+++ b/tests/test_recurrent.py
@@ -1,9 +1,35 @@
 # testing against keras
+# import tensorflow.keras as tfk
+# import tensorflow as tf
+# import numpy as np
+# from serket.nn.recurrent import  LSTMCell, ScanRNN
+
+# batch_size = 1
+# time_steps = 2
+# in_features = 3
+# hidden_features=2
+
+# inputs = np.ones([batch_size,time_steps, in_features]).astype(np.float32)
+# inp = tf.keras.Input(shape=(time_steps, in_features))
+# rnn = (tf.keras.layers.LSTM(hidden_features, return_sequences=True, return_state=False))(inp)
+# rnn = tf.keras.Model(inputs=inp, outputs=rnn)
+# # rnn(inputs)
+# w_in_to_hidden = jnp.array(rnn.weights[0].numpy())
+# w_hidden_to_hidden = jnp.array(rnn.weights[1].numpy())
+# b_hidden_to_hidden = jnp.array(rnn.weights[2].numpy())
+# x = jnp.ones([time_steps, in_features])
+# cell = LSTMCell(in_features, hidden_features, recurrent_weight_init_func="glorot_uniform", bias_init_func="zeros",
+#  weight_init_func="glorot_uniform")
+# cell = cell.at["in_to_hidden.weight"].set(w_in_to_hidden)
+# cell = cell.at["hidden_to_hidden.weight"].set(w_hidden_to_hidden)
+# cell = cell.at["hidden_to_hidden.bias"].set(b_hidden_to_hidden)
+# ScanRNN(cell, return_sequences=True)(x) ,rnn(inputs)
+
 
 import jax.numpy as jnp
 import numpy.testing as npt
 
-from serket.nn.recurrent import ConvLSTM1DCell, LSTMCell, ScanRNNCell, SimpleRNNCell
+from serket.nn.recurrent import ConvLSTM1DCell, LSTMCell, ScanRNN, SimpleRNNCell
 
 # import pytest
 
@@ -45,7 +71,7 @@ def test_vanilla_rnn():
     cell = cell.at["in_to_hidden.weight"].set(w_in_to_hidden)
     cell = cell.at["hidden_to_hidden.weight"].set(w_hidden_to_hidden)
 
-    sk_layer = ScanRNNCell(cell)
+    sk_layer = ScanRNN(cell)
     y = jnp.array([[0.9637042, -0.8282256, 0.7314449]])
     npt.assert_allclose(sk_layer(x), y)
 
@@ -162,7 +188,7 @@ def test_lstm():
     cell = cell.at["hidden_to_hidden.weight"].set(w_hidden_to_hidden)
     cell = cell.at["hidden_to_hidden.bias"].set(b_hidden_to_hidden)
 
-    sk_layer = ScanRNNCell(cell, return_sequences=False)
+    sk_layer = ScanRNN(cell, return_sequences=False)
     y = jnp.array([[0.18658024, -0.6338659, 0.3445018]])
     npt.assert_allclose(y, sk_layer(x), atol=1e-5)
 
@@ -259,7 +285,7 @@ def test_lstm():
     cell = cell.at["hidden_to_hidden.weight"].set(w_hidden_to_hidden)
     cell = cell.at["hidden_to_hidden.bias"].set(b_hidden_to_hidden)
 
-    sk_layer = ScanRNNCell(cell, return_sequences=True)
+    sk_layer = ScanRNN(cell, return_sequences=True)
 
     y = jnp.array(
         [
@@ -276,7 +302,7 @@ def test_lstm():
         ]
     )
 
-    npt.assert_allclose(y, sk_layer(x)[1].hidden_state, atol=1e-5)
+    npt.assert_allclose(y, sk_layer(x), atol=1e-5)
 
 
 def test_conv_lstm1d():
@@ -443,7 +469,7 @@ def test_conv_lstm1d():
 
     x = jnp.ones([time_steps, in_features, *spatial_dim])
 
-    res_sk = ScanRNNCell(cell, return_sequences=False)(x)
+    res_sk = ScanRNN(cell, return_sequences=False)(x)
 
     y = jnp.array(
         [

--- a/tests/test_recurrent.py
+++ b/tests/test_recurrent.py
@@ -1,0 +1,463 @@
+# testing against keras
+
+import jax.numpy as jnp
+import numpy.testing as npt
+
+from serket.nn.recurrent import ConvLSTM1DCell, LSTMCell, ScanRNNCell, SimpleRNNCell
+
+# import pytest
+
+
+def test_vanilla_rnn():
+
+    in_features = 2
+    hidden_features = 3
+    # batch_size = 1
+    time_steps = 10
+
+    # test against keras
+    # copy weights from keras to serket and compare outputs
+    # inputs = np.ones([batch_size,time_steps, in_features]).astype(np.float32)
+    # inp = tf.keras.Input(shape=(time_steps, in_features))
+    # rnn = (tf.keras.layers.SimpleRNN(hidden_features, return_sequences=False, return_state=False))(inp)
+    # rnn = tf.keras.Model(inputs=inp, outputs=rnn)
+
+    x = jnp.ones([time_steps, in_features]).astype(jnp.float32)
+
+    w_in_to_hidden = jnp.array(
+        [[0.6252413, -0.34832734, 0.6286191], [0.84620893, 0.52448165, 0.13104844]]
+    )
+
+    w_hidden_to_hidden = jnp.array(
+        [
+            [-0.24631214, -0.86077654, -0.44541454],
+            [-0.96763766, 0.24441445, 0.06276101],
+            [-0.05484254, -0.4464587, 0.893122],
+        ]
+    )
+
+    cell = SimpleRNNCell(
+        in_features=in_features,
+        hidden_features=hidden_features,
+        recurrent_weight_init_func="glorot_uniform",
+    )
+
+    cell = cell.at["in_to_hidden.weight"].set(w_in_to_hidden)
+    cell = cell.at["hidden_to_hidden.weight"].set(w_hidden_to_hidden)
+
+    sk_layer = ScanRNNCell(cell)
+    y = jnp.array([[0.9637042, -0.8282256, 0.7314449]])
+    npt.assert_allclose(sk_layer(x), y)
+
+
+def test_lstm():
+
+    # tensorflow
+    in_features = 2
+    hidden_features = 3
+    # batch_size = 1
+    time_steps = 10
+
+    # inputs = np.ones([batch_size,time_steps, in_features]).astype(np.float32)
+    # inp = tf.keras.Input(shape=(time_steps, in_features))
+    # rnn = (tf.keras.layers.LSTM(hidden_features, return_sequences=False, return_state=False))(inp)
+    # rnn = tf.keras.Model(inputs=inp, outputs=rnn)
+
+    # w_in_to_hidden = jnp.array(rnn.weights[0].numpy())
+    # w_hidden_to_hidden = jnp.array(rnn.weights[1].numpy())
+    # b_hidden_to_hidden = jnp.array(rnn.weights[2].numpy())
+
+    x = jnp.ones([time_steps, in_features]).astype(jnp.float32)
+
+    w_in_to_hidden = jnp.array(
+        [
+            [
+                -0.1619612,
+                -0.17861447,
+                -0.374527,
+                0.21063584,
+                0.1806348,
+                0.0344786,
+                0.44189203,
+                -0.55044144,
+                0.28518462,
+                -0.09390897,
+                0.56036115,
+                0.19108337,
+            ],
+            [
+                0.03269911,
+                -0.21127799,
+                0.55661833,
+                -0.6470987,
+                -0.27472985,
+                -0.21884575,
+                0.2479667,
+                -0.34201348,
+                0.00261247,
+                -0.6468279,
+                0.5003185,
+                0.6460693,
+            ],
+        ]
+    )
+
+    w_hidden_to_hidden = jnp.array(
+        [
+            [
+                0.3196982,
+                0.25284654,
+                -0.18152222,
+                0.44958767,
+                -0.44068673,
+                -0.19395973,
+                -0.00905689,
+                -0.17610262,
+                0.21773854,
+                -0.47118214,
+                -0.07700437,
+                0.24598895,
+            ],
+            [
+                -0.23678103,
+                -0.01854092,
+                -0.15681103,
+                -0.20309119,
+                -0.51169145,
+                0.33006623,
+                0.35155487,
+                0.1802753,
+                -0.08975402,
+                -0.30867696,
+                0.37548447,
+                -0.3264465,
+            ],
+            [
+                -0.14270899,
+                0.26242012,
+                -0.31327525,
+                0.206014,
+                0.5501963,
+                0.14983827,
+                -0.15515868,
+                0.2578809,
+                -0.14565073,
+                -0.33286166,
+                0.4204296,
+                0.21370588,
+            ],
+        ]
+    )
+
+    b_hidden_to_hidden = jnp.array(
+        [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    )
+
+    cell = LSTMCell(
+        in_features=in_features,
+        hidden_features=hidden_features,
+        recurrent_weight_init_func="glorot_uniform",
+    )
+    cell = cell.at["in_to_hidden.weight"].set(w_in_to_hidden)
+    cell = cell.at["hidden_to_hidden.weight"].set(w_hidden_to_hidden)
+    cell = cell.at["hidden_to_hidden.bias"].set(b_hidden_to_hidden)
+
+    sk_layer = ScanRNNCell(cell, return_sequences=False)
+    y = jnp.array([[0.18658024, -0.6338659, 0.3445018]])
+    npt.assert_allclose(y, sk_layer(x), atol=1e-5)
+
+    w_in_to_hidden = jnp.array(
+        [
+            [
+                0.11943924,
+                -0.609248,
+                -0.45503575,
+                -0.3439762,
+                -0.33675978,
+                0.05291432,
+                -0.12904513,
+                -0.22977036,
+                0.32492596,
+                0.06835997,
+                0.0484916,
+                0.07520777,
+            ],
+            [
+                0.39872873,
+                -0.08020723,
+                -0.4879259,
+                -0.61926323,
+                -0.45951623,
+                -0.44556192,
+                -0.05298251,
+                0.54848397,
+                0.19754452,
+                0.6012858,
+                -0.06859863,
+                0.16502213,
+            ],
+        ]
+    )
+
+    w_hidden_to_hidden = jnp.array(
+        [
+            [
+                0.18880641,
+                0.21262297,
+                -0.2961502,
+                0.33976135,
+                -0.09891935,
+                -0.00502901,
+                0.34378093,
+                0.4202192,
+                0.36584634,
+                0.08396737,
+                -0.4975226,
+                0.15165171,
+            ],
+            [
+                0.30486387,
+                -0.46795598,
+                -0.07052832,
+                0.51685417,
+                -0.23734125,
+                0.1711132,
+                0.16389124,
+                -0.08915165,
+                -0.02928232,
+                -0.2173849,
+                0.19655496,
+                -0.45694238,
+            ],
+            [
+                -0.1722902,
+                -0.23029403,
+                0.05032581,
+                0.21182823,
+                0.5298174,
+                -0.50670344,
+                -0.18930247,
+                0.30799994,
+                -0.18611868,
+                -0.08317372,
+                -0.26286182,
+                -0.30177474,
+            ],
+        ]
+    )
+
+    b_hidden_to_hidden = jnp.array(
+        [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    )
+
+    cell = LSTMCell(
+        in_features=in_features,
+        hidden_features=hidden_features,
+        recurrent_weight_init_func="glorot_uniform",
+    )
+    cell = cell.at["in_to_hidden.weight"].set(w_in_to_hidden)
+    cell = cell.at["hidden_to_hidden.weight"].set(w_hidden_to_hidden)
+    cell = cell.at["hidden_to_hidden.bias"].set(b_hidden_to_hidden)
+
+    sk_layer = ScanRNNCell(cell, return_sequences=True)
+
+    y = jnp.array(
+        [
+            [[-0.07431775, 0.05081949, 0.07480226]],
+            [[-0.12263095, 0.07622699, 0.1146026]],
+            [[-0.15380122, 0.0886446, 0.13589925]],
+            [[-0.17376699, 0.0944333, 0.14736715]],
+            [[-0.18647897, 0.09689739, 0.1535385]],
+            [[-0.19453025, 0.09775667, 0.15683244]],
+            [[-0.19960524, 0.09789205, 0.1585632]],
+            [[-0.20278986, 0.0977404, 0.15945096]],
+            [[-0.20477988, 0.09750732, 0.15989034]],
+            [[-0.20601842, 0.09728104, 0.16009602]],
+        ]
+    )
+
+    npt.assert_allclose(y, sk_layer(x)[1].hidden_state, atol=1e-5)
+
+
+def test_conv_lstm1d():
+    w_in_to_hidden = jnp.array(
+        [
+            [
+                [0.3159187, -0.37110862, 0.23497376],
+                [0.06916022, 0.16520068, -0.1498835],
+            ],
+            [
+                [0.13892826, -0.2475906, 0.11548725],
+                [-0.14935534, 0.0077568, 0.31523505],
+            ],
+            [
+                [0.20523027, 0.333159, -0.26372582],
+                [0.21769527, -0.28275424, 0.07145688],
+            ],
+            [
+                [-0.32436138, 0.17985162, -0.05102682],
+                [-0.33781663, 0.07652837, 0.14034107],
+            ],
+            [
+                [-0.2476197, 0.27073297, -0.15494357],
+                [-0.17142114, 0.0436784, -0.2635818],
+            ],
+            [
+                [-0.1563589, -0.30193892, -0.3076105],
+                [0.30359367, -0.37472126, 0.08727607],
+            ],
+            [
+                [0.02532503, -0.33569914, -0.16816947],
+                [-0.28197324, -0.20834318, -0.31490648],
+            ],
+            [
+                [0.37559494, -0.10307714, -0.28350165],
+                [0.16282192, 0.25434867, 0.14521858],
+            ],
+            [
+                [-0.3619054, -0.05932748, 0.13838741],
+                [0.317831, -0.01710135, 0.01839554],
+            ],
+            [
+                [-0.33236656, -0.15234765, 0.23833898],
+                [-0.0525074, -0.1169591, 0.22625437],
+            ],
+            [
+                [0.3350378, 0.3527101, -0.08017969],
+                [-0.25890553, 0.24611798, 0.30005935],
+            ],
+            [
+                [-0.07834777, -0.02483597, -0.28757787],
+                [-0.15855587, 0.14020738, -0.3187018],
+            ],
+        ]
+    )
+
+    w_hidden_to_hidden = jnp.array(
+        [
+            [
+                [0.44095814, 0.12996325, 0.1313585],
+                [0.18582591, 0.07248487, -0.7859758],
+                [-0.17839126, 0.15680492, -0.08622836],
+            ],
+            [
+                [-0.11601712, 0.00761805, 0.43996823],
+                [0.27362385, 0.0799137, 0.2580722],
+                [-0.563254, 0.19736156, 0.26167846],
+            ],
+            [
+                [-0.28901652, -0.25223732, -0.10025343],
+                [0.56027263, -0.28712046, -0.18524358],
+                [0.37074035, 0.3996833, 0.1725195],
+            ],
+            [
+                [0.07441625, 0.20128009, 0.30421543],
+                [-0.06981394, -0.17527759, 0.22605616],
+                [0.11372325, 0.63972735, -0.19949353],
+            ],
+            [
+                [0.08129799, -0.06646754, -0.44094074],
+                [-0.09799376, 0.16513337, 0.1980969],
+                [-0.01823295, 0.33500522, 0.19564764],
+            ],
+            [
+                [-0.4375121, -0.07695349, 0.27423194],
+                [0.25537497, 0.64107186, -0.09421141],
+                [0.21401826, -0.15687335, -0.07473418],
+            ],
+            [
+                [-0.37147775, 0.06210529, -0.04531584],
+                [-0.38045418, 0.26204777, -0.17553791],
+                [-0.16380772, 0.39306286, -0.444068],
+            ],
+            [
+                [-0.08250815, 0.5762788, 0.3014125],
+                [0.08091379, -0.20550683, 0.06467859],
+                [0.02479128, -0.16484486, 0.09149422],
+            ],
+            [
+                [-0.1793791, 0.23342696, -0.33710676],
+                [0.4355502, -0.23507121, 0.11481185],
+                [-0.21538775, -0.16292992, -0.6203824],
+            ],
+            [
+                [-0.1719443, 0.04258863, -0.35778967],
+                [0.12353352, 0.0826712, -0.10358769],
+                [-0.55321497, 0.07205058, 0.29797262],
+            ],
+            [
+                [-0.52755165, 0.27079415, -0.04477403],
+                [-0.3376618, -0.32239383, -0.3393156],
+                [0.04485175, -0.04528336, 0.30485243],
+            ],
+            [
+                [-0.14193594, -0.634814, 0.28351584],
+                [-0.16348608, -0.4000306, -0.08978741],
+                [-0.26926947, -0.12314601, -0.19621553],
+            ],
+        ]
+    )
+
+    b_hidden_to_hidden = jnp.array(
+        [
+            [0.0],
+            [0.0],
+            [0.0],
+            [1.0],
+            [1.0],
+            [1.0],
+            [0.0],
+            [0.0],
+            [0.0],
+            [0.0],
+            [0.0],
+            [0.0],
+        ]
+    )
+
+    in_features = 2
+    out_features = 3
+    time_steps = 1
+    spatial_dim = (3,)
+
+    # inputs = np.ones([batch_size,time_steps, in_features,*spatial_dim]).astype(np.float32)
+    # inp = tf.keras.Input(shape=(time_steps, in_features,*spatial_dim))
+    # rnn = (tf.keras.layers.ConvLSTM1D(out_features,recurrent_activation="sigmoid", kernel_size=3, padding='same',
+    # return_sequences=False,data_format='channels_first'))(inp)
+    # rnn = tf.keras.Model(inputs=inp, outputs=rnn)
+
+    cell = ConvLSTM1DCell(
+        in_features=in_features,
+        out_features=out_features,
+        recurrent_act_func="sigmoid",
+        kernel_size=3,
+        padding="same",
+        weight_init_func="glorot_uniform",
+        recurrent_weight_init_func="glorot_uniform",
+        bias_init_func="zeros",
+    )
+
+    cell = cell.at["in_to_hidden.weight"].set(w_in_to_hidden)
+    cell = cell.at["hidden_to_hidden.weight"].set(w_hidden_to_hidden)
+    cell = cell.at["hidden_to_hidden.bias"].set(b_hidden_to_hidden)
+
+    x = jnp.ones([time_steps, in_features, *spatial_dim])
+
+    res_sk = ScanRNNCell(cell, return_sequences=False)(x)
+
+    y = jnp.array(
+        [
+            [-0.19088623, -0.20386685, -0.11864982],
+            [0.00493522, 0.18935747, 0.16954307],
+            [0.01413723, 0.00672858, -0.03464129],
+        ]
+    )
+
+    assert jnp.allclose(res_sk, y, atol=1e-5)
+
+
+# def test_lazy_rnn():
+
+#     x = jnp.ones([10, 1])
+#     l = SimpleRNNCell(None, 10)
+#     assert l()


### PR DESCRIPTION
Add RNN layers
1) `SimpleRNNCell`
2) `LSTMCell`
3) `ConvLSTM{1D,2D,3D}`
4) `SeparableConvLSTM{1D,2D,3D}`
Use the `ScanRNN(cell=...,return_sequences=...)` to apply a cell over input vector  

API example
```python
in_features=10
hidden_features=20
time_steps= 10

# define cell 
cell = SimpleRNNCell(in_features,  hidden_features)

# scan the input vector
x = jnp.ones([time_steps, in_features])
# ScanRNN has a features similar to keras `return_sequences`
layer = ScanRNN(cell= cell, return_sequences=False)
layer(x) 
```
Spatial RNN example
```python

time_steps = 2
in_features = 3
out_features=10
kernel_size=3
spatial_dim = (5,)

x = jnp.ones([time_steps, in_features, *spatial_dim])

cell =  ConvLSTM1DCell(in_features,out_features,kernel_size, recurrent_weight_init_func="glorot_uniform")
ScanRNN(cell=cell)(x).shape # 10 features, 5 spatial dimensions
ScanRNN(cell=cell, return_sequences=True)(x).shape # 2 timesteps , 10 features, 5 spatial dimensions
```

