### PR TITLE
edits and state/eval addition

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,9 +1,5 @@
 name: pypi
-
-on:
-  release:
-    types: [created]
-
+on: workflow_dispatch
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -16,11 +12,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install build
+          pip install twine
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+          python -m build
+          python -m twine upload dist/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+https://github.com/ASEM000/PyTreeClass
-          python -m pip install tensorflow
+          python -m pip install pytreeclass>=0.4.0
+          python -m pip install keras_core>=0.1.1
           python -m pip install pytest wheel optax jaxlib coverage kernex
       - name: Pytest Check
         run: |

--- a/serket/__init__.py
+++ b/serket/__init__.py
@@ -27,6 +27,7 @@ from pytreeclass import (
     is_tree_equal,
     tree_diagram,
     tree_flatten_with_trace,
+    tree_graph,
     tree_leaves_with_trace,
     tree_map_with_trace,
     tree_mask,
@@ -40,6 +41,8 @@ from pytreeclass import (
 )
 
 from . import nn
+from .nn.evaluation import tree_evaluation
+from .nn.state import tree_state
 
 __all__ = (
     # general utils
@@ -49,6 +52,7 @@ __all__ = (
     "fields",
     # pprint utils
     "tree_diagram",
+    "tree_graph",
     "tree_mermaid",
     "tree_repr",
     "tree_str",
@@ -72,7 +76,9 @@ __all__ = (
     "Partial",
     # serket
     "nn",
+    "tree_evaluation",
+    "tree_state",
 )
 
 
-__version__ = "0.2.0b7"
+__version__ = "0.4.0b1"

--- a/serket/nn/__init__.py
+++ b/serket/nn/__init__.py
@@ -86,16 +86,8 @@ from .fft_convolution import (
 from .flatten import Flatten, Unflatten
 from .flip import FlipLeftRight2D, FlipUpDown2D
 from .fully_connected import FNN, MLP
-from .linear import (
-    Bilinear,
-    Embedding,
-    GeneralLinear,
-    Identity,
-    Linear,
-    MergeLinear,
-    Multilinear,
-)
-from .normalization import GroupNorm, InstanceNorm, LayerNorm
+from .linear import Bilinear, Embedding, GeneralLinear, Identity, Linear, Multilinear
+from .normalization import BatchNorm, GroupNorm, InstanceNorm, LayerNorm
 from .padding import Pad1D, Pad2D, Pad3D
 from .pooling import (
     AdaptiveAvgPool1D,
@@ -149,7 +141,6 @@ __all__ = (
     "Multilinear",
     "GeneralLinear",
     "Embedding",
-    "MergeLinear",
     # Dropout
     "Dropout",
     "Dropout1D",
@@ -215,6 +206,7 @@ __all__ = (
     "LayerNorm",
     "InstanceNorm",
     "GroupNorm",
+    "BatchNorm",
     # Blur
     "AvgBlur2D",
     "GaussianBlur2D",

--- a/serket/nn/contrast.py
+++ b/serket/nn/contrast.py
@@ -95,9 +95,10 @@ class RandomContrastND(sk.TreeClass):
             and len(contrast_range) == 2
             and contrast_range[0] <= contrast_range[1]
         ):
-            msg = "contrast_range must be a tuple of two floats, "
-            msg += "with the first one smaller than the second one."
-            raise ValueError(msg)
+            raise ValueError(
+                "`contrast_range` must be a tuple of two floats, "
+                "with the first one smaller than the second one."
+            )
 
         self.contrast_range = contrast_range
 

--- a/serket/nn/convolution.py
+++ b/serket/nn/convolution.py
@@ -81,24 +81,20 @@ class ConvND(sk.TreeClass):
             self.spatial_ndim,
             name="kernel_dilation",
         )
-        self.weight_init_func = resolve_init_func(weight_init_func)
-        self.bias_init_func = resolve_init_func(bias_init_func)
+
+        weight_init_func = resolve_init_func(weight_init_func)
+        bias_init_func = resolve_init_func(bias_init_func)
+
         self.groups = positive_int_cb(groups)
 
         if self.out_features % self.groups != 0:
-            raise ValueError(
-                f"Expected out_features % groups == 0, \n"
-                f"got {self.out_features % self.groups}"
-            )
+            raise ValueError(f"{(out_features % groups == 0)=}")
 
         weight_shape = (out_features, in_features // groups, *self.kernel_size)
-        self.weight = self.weight_init_func(key, weight_shape)
+        self.weight = weight_init_func(key, weight_shape)
 
-        if bias_init_func is None:
-            self.bias = None
-        else:
-            bias_shape = (out_features, *(1,) * self.spatial_ndim)
-            self.bias = self.bias_init_func(key, bias_shape)
+        bias_shape = (out_features, *(1,) * self.spatial_ndim)
+        self.bias = bias_init_func(key, bias_shape)
 
     @ft.partial(validate_spatial_ndim, attribute_name="spatial_ndim")
     @ft.partial(validate_axis_shape, attribute_name="in_features", axis=0)
@@ -432,24 +428,18 @@ class ConvNDTranspose(sk.TreeClass):
             self.spatial_ndim,
             name="kernel_dilation",
         )
-        self.weight_init_func = resolve_init_func(weight_init_func)
-        self.bias_init_func = resolve_init_func(bias_init_func)
+        weight_init_func = resolve_init_func(weight_init_func)
+        bias_init_func = resolve_init_func(bias_init_func)
         self.groups = positive_int_cb(groups)
 
         if self.out_features % self.groups != 0:
-            raise ValueError(
-                "Expected out_features % groups == 0,"
-                f"got {self.out_features % self.groups}"
-            )
+            raise ValueError(f"{(self.out_features % self.groups ==0)=}")
 
         weight_shape = (out_features, in_features // groups, *self.kernel_size)  # OIHW
-        self.weight = self.weight_init_func(key, weight_shape)
+        self.weight = weight_init_func(key, weight_shape)
 
-        if bias_init_func is None:
-            self.bias = None
-        else:
-            bias_shape = (out_features, *(1,) * self.spatial_ndim)
-            self.bias = self.bias_init_func(key, bias_shape)
+        bias_shape = (out_features, *(1,) * self.spatial_ndim)
+        self.bias = bias_init_func(key, bias_shape)
 
     @ft.partial(validate_spatial_ndim, attribute_name="spatial_ndim")
     @ft.partial(validate_axis_shape, attribute_name="in_features", axis=0)
@@ -774,19 +764,18 @@ class DepthwiseConvND(sk.TreeClass):
         self.padding = padding  # delayed canonicalization
         self.input_dilation = canonicalize(1, self.spatial_ndim, name="input_dilation")
         self.kernel_dilation = canonicalize(
-            1, self.spatial_ndim, name="kernel_dilation"
+            1,
+            self.spatial_ndim,
+            name="kernel_dilation",
         )
-        self.weight_init_func = resolve_init_func(weight_init_func)
-        self.bias_init_func = resolve_init_func(bias_init_func)
+        weight_init_func = resolve_init_func(weight_init_func)
+        bias_init_func = resolve_init_func(bias_init_func)
 
         weight_shape = (depth_multiplier * in_features, 1, *self.kernel_size)  # OIHW
-        self.weight = self.weight_init_func(key, weight_shape)
+        self.weight = weight_init_func(key, weight_shape)
 
-        if bias_init_func is None:
-            self.bias = None
-        else:
-            bias_shape = (depth_multiplier * in_features, *(1,) * self.spatial_ndim)
-            self.bias = self.bias_init_func(key, bias_shape)
+        bias_shape = (depth_multiplier * in_features, *(1,) * self.spatial_ndim)
+        self.bias = bias_init_func(key, bias_shape)
 
     @ft.partial(validate_spatial_ndim, attribute_name="spatial_ndim")
     @ft.partial(validate_axis_shape, attribute_name="in_features", axis=0)
@@ -1359,8 +1348,8 @@ class ConvNDLocal(sk.TreeClass):
             self.spatial_ndim,
             name="kernel_dilation",
         )
-        self.weight_init_func = resolve_init_func(weight_init_func)
-        self.bias_init_func = resolve_init_func(bias_init_func)
+        weight_init_func = resolve_init_func(weight_init_func)
+        bias_init_func = resolve_init_func(bias_init_func)
 
         out_size = calculate_convolution_output_shape(
             shape=self.in_size,
@@ -1376,14 +1365,10 @@ class ConvNDLocal(sk.TreeClass):
             *out_size,
         )
 
-        self.weight = self.weight_init_func(key, weight_shape)
+        self.weight = weight_init_func(key, weight_shape)
 
         bias_shape = (self.out_features, *out_size)
-
-        if bias_init_func is None:
-            self.bias = None
-        else:
-            self.bias = self.bias_init_func(key, bias_shape)
+        self.bias = bias_init_func(key, bias_shape)
 
     @ft.partial(validate_spatial_ndim, attribute_name="spatial_ndim")
     @ft.partial(validate_axis_shape, attribute_name="in_features", axis=0)

--- a/serket/nn/dropout.py
+++ b/serket/nn/dropout.py
@@ -22,6 +22,8 @@ import jax.random as jr
 from jax import lax
 
 import serket as sk
+from serket.nn.evaluation import tree_evaluation
+from serket.nn.linear import Identity
 from serket.nn.utils import Range, validate_spatial_ndim
 
 
@@ -38,7 +40,7 @@ class Dropout(sk.TreeClass):
         >>> import jax.numpy as jnp
         >>> layer = sk.nn.Dropout(0.5)
         >>> # change `p` to 0.0 to turn off dropout
-        >>> layer = layer.at["p"].set(0.0, is_leaf=pytc.is_frozen)
+        >>> layer = layer.at["p"].set(0.0, is_leaf=sk.is_frozen)
 
     Note:
         Use `p`= 0.0 to turn off dropout.
@@ -157,3 +159,10 @@ class Dropout3D(DropoutND):
     @property
     def spatial_ndim(self) -> int:
         return 3
+
+
+@tree_evaluation.def_evalutation(Dropout)
+@tree_evaluation.def_evalutation(DropoutND)
+def dropout_evaluation(_):
+    # dropout is a no-op during evaluation
+    return Identity()

--- a/serket/nn/evaluation.py
+++ b/serket/nn/evaluation.py
@@ -1,0 +1,58 @@
+# Copyright 2023 Serket authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Define dispatchers for custom tree evaluation."""
+
+from __future__ import annotations
+
+import functools as ft
+from typing import Any, Callable, TypeVar
+
+import jax
+
+T = TypeVar("T")
+
+
+def tree_evaluation(tree: T) -> T:
+    """Modify tree layers to disable any trainning related behavior.
+
+    For example, `Dropout` layers drop probability is set to 0.0. and `BatchNorm`
+    layer `track_running_stats` is set to False when evaluating the tree.
+
+    Args:
+        tree: A tree of layers.
+
+    Returns:
+        A tree of layers with evaluation behavior.
+
+    Example:
+        >>> # dropout is replaced by an identity layer in evaluation mode
+        >>> # by registering `tree_evaluation.def_evaluation(sk.nn.Dropout, sk.nn.Identity)`
+        >>> import jax.numpy as jnp
+        >>> import serket as sk
+        >>> layer = sk.nn.Dropout(0.5)
+        >>> sk.tree_evaluation(layer)
+        Identity()
+    """
+
+    def is_leaf(x: Callable[[Any], bool]) -> bool:
+        types = set(tree_evaluation.evaluation_dispatcher.registry.keys())
+        types.discard(object)
+        return isinstance(x, tuple(types))
+
+    return jax.tree_map(tree_evaluation.evaluation_dispatcher, tree, is_leaf=is_leaf)
+
+
+tree_evaluation.evaluation_dispatcher = ft.singledispatch(lambda x: x)
+tree_evaluation.def_evalutation = tree_evaluation.evaluation_dispatcher.register

--- a/serket/nn/fft_convolution.py
+++ b/serket/nn/fft_convolution.py
@@ -179,8 +179,8 @@ class FFTConvND(sk.TreeClass):
             self.spatial_ndim,
             name="kernel_dilation",
         )
-        self.weight_init_func = resolve_init_func(weight_init_func)
-        self.bias_init_func = resolve_init_func(bias_init_func)
+        weight_init_func = resolve_init_func(weight_init_func)
+        bias_init_func = resolve_init_func(bias_init_func)
         self.groups = positive_int_cb(groups)
 
         if self.out_features % self.groups != 0:
@@ -188,13 +188,10 @@ class FFTConvND(sk.TreeClass):
             raise ValueError(msg)
 
         weight_shape = (out_features, in_features // groups, *self.kernel_size)
-        self.weight = self.weight_init_func(key, weight_shape)
+        self.weight = weight_init_func(key, weight_shape)
 
-        if bias_init_func is None:
-            self.bias = None
-        else:
-            bias_shape = (out_features, *(1,) * self.spatial_ndim)
-            self.bias = self.bias_init_func(key, bias_shape)
+        bias_shape = (out_features, *(1,) * self.spatial_ndim)
+        self.bias = bias_init_func(key, bias_shape)
 
     @ft.partial(validate_spatial_ndim, attribute_name="spatial_ndim")
     @ft.partial(validate_axis_shape, attribute_name="in_features", axis=0)
@@ -513,8 +510,8 @@ class FFTConvNDTranspose(sk.TreeClass):
             self.spatial_ndim,
             name="kernel_dilation",
         )
-        self.weight_init_func = resolve_init_func(weight_init_func)
-        self.bias_init_func = resolve_init_func(bias_init_func)
+        weight_init_func = resolve_init_func(weight_init_func)
+        bias_init_func = resolve_init_func(bias_init_func)
         self.groups = positive_int_cb(groups)
 
         if self.in_features % self.groups != 0:
@@ -524,13 +521,13 @@ class FFTConvNDTranspose(sk.TreeClass):
             )
 
         weight_shape = (out_features, in_features // groups, *self.kernel_size)  # OIHW
-        self.weight = self.weight_init_func(key, weight_shape)
+        self.weight = weight_init_func(key, weight_shape)
 
         if bias_init_func is None:
             self.bias = None
         else:
             bias_shape = (out_features, *(1,) * self.spatial_ndim)
-            self.bias = self.bias_init_func(key, bias_shape)
+            self.bias = bias_init_func(key, bias_shape)
 
     @ft.partial(validate_spatial_ndim, attribute_name="spatial_ndim")
     @ft.partial(validate_axis_shape, attribute_name="in_features", axis=0)
@@ -857,19 +854,18 @@ class DepthwiseFFTConvND(sk.TreeClass):
         self.padding = padding
         self.input_dilation = canonicalize(1, self.spatial_ndim, name="input_dilation")
         self.kernel_dilation = canonicalize(
-            1, self.spatial_ndim, name="kernel_dilation"
+            1,
+            self.spatial_ndim,
+            name="kernel_dilation",
         )
-        self.weight_init_func = resolve_init_func(weight_init_func)
-        self.bias_init_func = resolve_init_func(bias_init_func)
+        weight_init_func = resolve_init_func(weight_init_func)
+        bias_init_func = resolve_init_func(bias_init_func)
 
         weight_shape = (depth_multiplier * in_features, 1, *self.kernel_size)  # OIHW
-        self.weight = self.weight_init_func(key, weight_shape)
+        self.weight = weight_init_func(key, weight_shape)
 
-        if bias_init_func is None:
-            self.bias = None
-        else:
-            bias_shape = (depth_multiplier * in_features, *(1,) * self.spatial_ndim)
-            self.bias = self.bias_init_func(key, bias_shape)
+        bias_shape = (depth_multiplier * in_features, *(1,) * self.spatial_ndim)
+        self.bias = bias_init_func(key, bias_shape)
 
     @ft.partial(validate_spatial_ndim, attribute_name="spatial_ndim")
     @ft.partial(validate_axis_shape, attribute_name="in_features", axis=0)

--- a/serket/nn/initialization.py
+++ b/serket/nn/initialization.py
@@ -62,7 +62,7 @@ inits = [
 init_map: dict[str, InitType] = dict(zip(get_args(InitLiteral), inits))
 
 
-def resolve_init_func(init_func: str | Callable) -> Callable:
+def resolve_init_func(init_func: str | InitFuncType) -> Callable:
     if isinstance(init_func, FunctionType):
         return jtu.Partial(init_func)
 
@@ -74,6 +74,6 @@ def resolve_init_func(init_func: str | Callable) -> Callable:
         raise ValueError(f"value must be one of ({', '.join(init_map.keys())})")
 
     if init_func is None:
-        return None
+        return jtu.Partial(lambda key, shape, dtype=None: None)
 
     raise ValueError("Value must be a string or a function.")

--- a/serket/nn/normalization.py
+++ b/serket/nn/normalization.py
@@ -14,14 +14,16 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
-
 import jax
 import jax.numpy as jnp
+import jax.random as jr
 from jax.custom_batching import custom_vmap
 
 import serket as sk
-from serket.nn.utils import IsInstance, Range, ScalarLike, positive_int_cb
+from serket.nn.evaluation import tree_evaluation
+from serket.nn.initialization import InitType, resolve_init_func
+from serket.nn.state import tree_state
+from serket.nn.utils import Range, ScalarLike, positive_int_cb
 
 
 def layer_norm(
@@ -49,8 +51,12 @@ def layer_norm(
     σ_2 = jnp.var(x, axis=dims, keepdims=True)
     x̂ = (x - μ) * jax.lax.rsqrt((σ_2 + eps))
 
-    if gamma is not None and beta is not None:
-        return x̂ * gamma + beta
+    if gamma is not None:
+        x̂ = x̂ * gamma
+
+    if beta is not None:
+        x̂ = x̂ + beta
+
     return x̂
 
 
@@ -80,10 +86,13 @@ def group_norm(
     x̂ = (xx - μ) * jax.lax.rsqrt((σ_2 + eps))
     x̂ = x̂.reshape(*x.shape)
 
-    if gamma is not None and beta is not None:
+    if gamma is not None:
         gamma = jnp.expand_dims(gamma, axis=range(1, x.ndim))
+        x̂ *= gamma
+
+    if beta is not None:
         beta = jnp.expand_dims(beta, axis=range(1, x.ndim))
-        x̂ = x̂ * gamma + beta
+        x̂ += beta
     return x̂
 
 
@@ -95,17 +104,23 @@ class LayerNorm(sk.TreeClass):
     Args:
         normalized_shape: the shape of the input to be normalized.
         eps: a value added to the denominator for numerical stability.
-        affine: a boolean value that when set to True, this module has learnable affine parameters.
+        gamma_init_func: a function to initialize the scale. Defaults to ones.
+            if None, the scale is not trainable.
+        beta_init_func: a function to initialize the shift. Defaults to zeros.
+            if None, the shift is not trainable.
+        key: a random key for initialization. Defaults to jax.random.PRNGKey(0).
     """
 
-    eps: float = sk.field(callbacks=[Range(0), ScalarLike()])
+    eps: float = sk.field(callbacks=[Range(0, min_inclusive=False), ScalarLike()])
 
     def __init__(
         self,
         normalized_shape: int | tuple[int, ...],
         *,
         eps: float = 1e-5,
-        affine: bool = True,
+        gamma_init_func: InitType = "ones",
+        beta_init_func: InitType = "zeros",
+        key: jr.KeyArray = jr.PRNGKey(0),
     ):
         self.normalized_shape = (
             normalized_shape
@@ -113,11 +128,8 @@ class LayerNorm(sk.TreeClass):
             else (normalized_shape,)
         )
         self.eps = eps
-        self.affine = affine
-
-        # make gamma and beta trainable
-        self.gamma = jnp.ones(normalized_shape) if self.affine else None
-        self.beta = jnp.zeros(normalized_shape) if self.affine else None
+        self.gamma = resolve_init_func(gamma_init_func)(key, self.normalized_shape)
+        self.beta = resolve_init_func(beta_init_func)(key, self.normalized_shape)
 
     def __call__(self, x: jax.Array, **kwargs) -> jax.Array:
         return layer_norm(
@@ -138,7 +150,11 @@ class GroupNorm(sk.TreeClass):
         in_features : the shape of the input to be normalized.
         groups : number of groups to separate the channels into.
         eps : a value added to the denominator for numerical stability.
-        affine : a boolean value that when set to True, this module has learnable affine parameters.
+        gamma_init_func: a function to initialize the scale. Defaults to ones.
+            if None, the scale is not trainable.
+        beta_init_func: a function to initialize the shift. Defaults to zeros.
+            if None, the shift is not trainable.
+        key: a random key for initialization. Defaults to jax.random.PRNGKey(0).
     """
 
     eps: float = sk.field(callbacks=[Range(0), ScalarLike()])
@@ -149,21 +165,20 @@ class GroupNorm(sk.TreeClass):
         *,
         groups: int,
         eps: float = 1e-5,
-        affine: bool = True,
+        gamma_init_func: InitType = "ones",
+        beta_init_func: InitType = "zeros",
+        key: jr.KeyArray = jr.PRNGKey(0),
     ):
         self.in_features = positive_int_cb(in_features)
         self.groups = positive_int_cb(groups)
-        self.affine = affine
         self.eps = eps
 
         # needs more info for checking
         if in_features % groups != 0:
-            msg = f"in_features must be divisible by groups. Got {in_features} and {groups}"
-            raise ValueError(msg)
+            raise ValueError(f"{in_features} must be divisible by {groups=}.")
 
-        # make gamma and beta trainable
-        self.gamma = jnp.ones(self.in_features) if self.affine else None
-        self.beta = jnp.zeros(self.in_features) if self.affine else None
+        self.gamma = resolve_init_func(gamma_init_func)(key, (in_features,))
+        self.beta = resolve_init_func(beta_init_func)(key, (in_features,))
 
     def __call__(self, x: jax.Array, **k) -> jax.Array:
         return group_norm(
@@ -183,7 +198,11 @@ class InstanceNorm(GroupNorm):
     Args:
         in_features : the shape of the input to be normalized.
         eps : a value added to the denominator for numerical stability.
-        affine : a boolean value that when set to True, this module has learnable affine parameters.
+        gamma_init_func: a function to initialize the scale. Defaults to ones.
+            if None, the scale is not trainable.
+        beta_init_func: a function to initialize the shift. Defaults to zeros.
+            if None, the shift is not trainable.
+        key: a random key for initialization. Defaults to jax.random.PRNGKey(0).
     """
 
     def __init__(
@@ -191,33 +210,86 @@ class InstanceNorm(GroupNorm):
         in_features: int,
         *,
         eps: float = 1e-5,
-        affine: bool = True,
+        gamma_init_func: InitType = "ones",
+        beta_init_func: InitType = "zeros",
+        key: jr.KeyArray = jr.PRNGKey(0),
     ):
         super().__init__(
             in_features=in_features,
             groups=in_features,
             eps=eps,
-            affine=affine,
+            gamma_init_func=gamma_init_func,
+            beta_init_func=beta_init_func,
+            key=key,
         )
 
 
-class BatchNormState(NamedTuple):
+class BatchNormState(sk.TreeClass):
     running_mean: jax.Array
     running_var: jax.Array
+
+
+def _batchnorm_impl(
+    x: jax.Array,
+    state: BatchNormState,
+    momentum: float = 0.1,
+    eps: float = 1e-3,
+    gamma: jax.Array = None,
+    beta: jax.Array = None,
+    evalution: bool = False,
+    axis: int = 1,
+):
+    # reduce over axis=1
+    broadcast_shape = [1] * x.ndim
+    broadcast_shape[axis] = x.shape[axis]
+
+    def bn_eval_step(x, state):
+        run_mean, run_var = state.running_mean, state.running_var
+        run_mean = jnp.reshape(run_mean, broadcast_shape)
+        run_var = jnp.reshape(run_var, broadcast_shape)
+        output = (x - run_mean) / jnp.sqrt(run_var + eps)
+
+        return output, state
+
+    def bn_train_step(x, state):
+        # maybe support axes option
+        run_mean, run_var = state.running_mean, state.running_var
+        axes = list(range(x.ndim))
+        with jax.ensure_compile_time_eval():
+            del axes[axis]
+        batch_mean = jnp.mean(x, axis=axes, keepdims=True)
+        batch_var = jnp.mean(jnp.square(x), axis=axes, keepdims=True) - batch_mean**2
+        output = (x - batch_mean) / jnp.sqrt(batch_var + eps)
+        run_mean = momentum * run_mean + (1 - momentum) * jnp.squeeze(batch_mean)
+        run_var = momentum * run_var + (1 - momentum) * jnp.squeeze(batch_var)
+        return output, BatchNormState(run_mean, run_var)
+
+    output, state = jax.lax.cond(evalution, bn_eval_step, bn_train_step, x, state)
+
+    state = jax.lax.stop_gradient(state)
+
+    if gamma is not None:
+        output *= jnp.reshape(gamma, broadcast_shape)
+
+    if beta is not None:
+        output += jnp.reshape(beta, broadcast_shape)
+
+    return output, state
 
 
 @custom_vmap
 def batchnorm(
     x: jax.Array,
-    state: tuple[jax.Array, jax.Array],
-    *,
+    state: BatchNormState,
     momentum: float = 0.1,
     eps: float = 1e-5,
     gamma: jax.Array | None = None,
     beta: jax.Array | None = None,
-    track_running_stats: bool = False,
-):
-    del momentum, eps, gamma, beta, track_running_stats
+    evaluation: bool = False,
+    axis: int = 1,
+) -> tuple[jax.Array, BatchNormState]:
+    del momentum, eps, gamma, beta, evaluation, axis
+    # no-op when unbatched
     return x, state
 
 
@@ -226,40 +298,106 @@ def _(
     axis_size,
     in_batched,
     x: jax.Array,
-    state: tuple[jax.Array, jax.Array],
-    *,
-    momentum: float = 0.1,
-    eps: float = 1e-5,
-    track_running_stats: bool = True,
-):
-    run_mean, run_var = state
-
-    axes = [0] + list(range(2, x.ndim))
-
-    batch_mean, batch_var = jnp.mean(x, axis=axes), jnp.var(x, axis=axes)
-
-    run_mean = jnp.where(
-        track_running_stats,
-        (1 - momentum) * run_mean + momentum * batch_mean,
-        batch_mean,
+    state: BatchNormState,
+    momentum: float = 0.99,
+    eps: float = 1e-3,
+    gamma: jax.Array | None = None,
+    beta: jax.Array | None = None,
+    evaluation: bool = True,
+    axis: int = 1,
+) -> tuple[jax.Array, BatchNormState]:
+    output = _batchnorm_impl(
+        x=x,
+        state=state,
+        momentum=momentum,
+        eps=eps,
+        gamma=gamma,
+        beta=beta,
+        evalution=evaluation,
+        axis=axis,
     )
-
-    run_var = jnp.where(
-        track_running_stats,
-        (1 - momentum) * run_var + momentum * batch_var * (axis_size / (axis_size - 1)),
-        batch_var,
-    )
-    x_normalized = (x - batch_mean) * jax.lax.rsqrt(batch_var + eps)
-    return (x_normalized, (run_mean, run_var)), (True, (True, True))
+    return output, (True, BatchNormState(True, True))
 
 
 class BatchNorm(sk.TreeClass):
-    in_features: int = sk.field(callbacks=[IsInstance(int), Range(1)])
-    momentum: float = sk.field(callbacks=[Range(0, 1), ScalarLike()])
-    eps: float = sk.field(callbacks=[Range(0), ScalarLike()])
-    track_running_stats: bool = sk.field(callbacks=[IsInstance(bool)])
+    """Applies normalization over batched inputs`
 
-    def __post_init__(self):
-        self.state = BatchNormState(
-            jnp.zeros(self.in_features), jnp.ones(self.in_features)
+    Works under ``jax.vmap(BatchNorm(...), in_axes=(0, None))``, otherwise will be a no-op.
+
+    Evaluation behavior:
+        ``output = (x - running_mean) / sqrt(running_var + eps)``
+
+    Training behavior:
+        ``output = (x - batch_mean) / sqrt(batch_var + eps)``
+        ``running_mean = momentum * running_mean + (1 - momentum) * batch_mean``
+        ``running_var = momentum * running_var + (1 - momentum) * batch_var``
+
+    Args:
+        in_features : the shape of the input to be normalized.
+        momentum : the value used for the ``running_mean`` and ``running_var``
+            computation. must be a number between ``0`` and ``1``.
+        eps : a value added to the denominator for numerical stability.
+        gamma_init_func: a function to initialize the scale. Defaults to ones.
+            if None, the scale is not trainable.
+        beta_init_func: a function to initialize the shift. Defaults to zeros.
+            if None, the shift is not trainable.
+        axis: the axis that should be normalized. Defaults to 1.
+        evaluation : a boolean value that when set to True, this module will run in
+            evaluation mode. In this case, this module will always use the running
+            estimates of the batch statistics during training.
+
+    Note:
+        https://keras.io/api/layers/normalization_layers/batch_normalization/
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        *,
+        momentum: float = 0.99,
+        eps: float = 1e-3,
+        gamma_init_func: InitType = "ones",
+        beta_init_func: InitType = "zeros",
+        axis: int = 1,
+        evaluation: bool = False,
+        key: jr.KeyArray = jr.PRNGKey(0),
+    ) -> None:
+        self.in_features = in_features
+        self.momentum = momentum
+        self.eps = eps
+        self.gamma = resolve_init_func(gamma_init_func)(key, (in_features,))
+        self.beta = resolve_init_func(beta_init_func)(key, (in_features,))
+        self.axis = axis
+        self.evaluation = evaluation
+
+    def __call__(
+        self,
+        x: jax.Array,
+        state: BatchNormState | None = None,
+        **k,
+    ) -> jax.Array:
+        state = sk.tree_state(self) if state is None else state
+
+        x, state = batchnorm(
+            x,
+            state,
+            self.momentum,
+            self.eps,
+            self.gamma,
+            self.beta,
+            self.evaluation,
+            self.axis,
         )
+        return x, state
+
+
+@tree_evaluation.def_evalutation(BatchNorm)
+def _(batchnorm: BatchNorm) -> BatchNorm:
+    return batchnorm.at["evaluation"].set(True)
+
+
+@tree_state.def_state(BatchNorm)
+def batchnorm_init_state(batchnorm: BatchNorm, _) -> BatchNormState:
+    running_mean = jnp.zeros([batchnorm.in_features])
+    running_var = jnp.ones([batchnorm.in_features])
+    return BatchNormState(running_mean, running_var)

--- a/serket/nn/state.py
+++ b/serket/nn/state.py
@@ -1,0 +1,91 @@
+# Copyright 2023 Serket authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Define dispatchers for custom tree state."""
+
+from __future__ import annotations
+
+import functools as ft
+from typing import Any, Callable, TypeVar
+
+import jax
+
+import serket as sk
+
+T = TypeVar("T")
+
+
+class NoState(sk.TreeClass):
+    """No state placeholder."""
+
+    def __init__(self, _: Any, __: Any):
+        del _, __
+
+
+def tree_state(tree: T, array: jax.Array | None = None) -> T:
+    """Build state for a tree of layers.
+
+    Some layers require state to be initialized before training. For example,
+    `BatchNorm` layers require `running_mean` and `running_var` to be initialized
+    before training. This function initializes the state for a tree of layers,
+    based on the layer defined ``state`` rule using ``tree_state.def_state``.
+
+    Args:
+        tree: A tree of layers.
+        array: An array to use for initializing state required by some layers
+            (e.g. ConvGRUNDCell). default: ``None``.
+
+    Returns:
+        A tree of state leaves if it has state, otherwise ``None``.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import serket as sk
+        >>> tree = [1, 2, sk.nn.BatchNorm(5)]
+        >>> sk.tree_state(tree)
+        [NoState(), NoState(), BatchNormState(
+          running_mean=f32[5](μ=0.00, σ=0.00, ∈(0.00,0.00)),
+          running_var=f32[5](μ=1.00, σ=0.00, ∈(1.00,1.00))
+        )]
+
+    Example:
+        >>> # define state initialization rule for a custom layer
+        >>> import jax
+        >>> import serket as sk
+        >>> class LayerWithState(sk.TreeClass):
+        ...    pass
+        >>> # state function accept the `layer` and optional input array as arguments
+        >>> @sk.tree_state.def_state(LayerWithState)
+        ... def _(leaf, _):
+        ...    del _  # array is not used
+        ...    return "some state"
+        >>> sk.tree_state(LayerWithState())
+        'some state'
+        >>> sk.tree_state(LayerWithState(), jax.numpy.ones((1, 1)))
+        'some state'
+    """
+
+    def is_leaf(x: Callable[[Any], bool]) -> bool:
+        types = set(tree_state.state_dispatcher.registry.keys())
+        types.discard(object)
+        return isinstance(x, tuple(types))
+
+    def dispatch_func(node):
+        return tree_state.state_dispatcher(node, array)
+
+    return jax.tree_map(dispatch_func, tree, is_leaf=is_leaf)
+
+
+tree_state.state_dispatcher = ft.singledispatch(NoState)
+tree_state.def_state = tree_state.state_dispatcher.register

--- a/serket/nn/utils.py
+++ b/serket/nn/utils.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import functools as ft
+import operator as op
 from typing import Any, Sequence, Tuple, Union
 
 import jax
@@ -184,11 +185,17 @@ class Range(sk.TreeClass):
 
     min_val: float = -float("inf")
     max_val: float = float("inf")
+    min_inclusive: bool = True
+    max_inclusive: bool = True
 
     def __call__(self, value: Any):
-        if self.min_val <= value <= self.max_val:
+        lop, ls = (op.ge, "[") if self.min_inclusive else (op.gt, "(")
+        rop, rs = (op.le, "]") if self.max_inclusive else (op.lt, ")")
+
+        if lop(value, self.min_val) and rop(value, self.max_val):
             return value
-        raise ValueError(f"Not in range[{self.min_val}, {self.max_val}] got {value=}.")
+
+        raise ValueError(f"Not in {ls}{self.min_val}, {self.max_val}{rs} got {value=}.")
 
 
 class IsInstance(sk.TreeClass):

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -26,7 +26,6 @@ from serket.nn import (
     GeneralLinear,
     Identity,
     Linear,
-    MergeLinear,
     Multilinear,
 )
 
@@ -144,20 +143,3 @@ def test_general_linear():
 
     with pytest.raises(ValueError):
         GeneralLinear(in_features=(1,), in_axes=(0, -3), out_features=5)
-
-
-def test_merge_linear():
-    layer1 = Linear(5, 6)  # 5 input features, 6 output features
-    layer2 = Linear(7, 6)  # 7 input features, 6 output features
-    merged_layer = MergeLinear(layer1, layer2)  # 12 input features, 6 output features
-    x1 = jnp.ones([1, 5])  # 1 sample, 5 features
-    x2 = jnp.ones([1, 7])  # 1 sample, 7 features
-    y = merged_layer(x1, x2)
-    z = layer1(x1) + layer2(x2)
-    npt.assert_allclose(y, z, atol=1e-6)
-
-    with pytest.raises(ValueError):
-        # output features of layer1 and layer2 mismatch
-        l1 = Linear(5, 6)
-        l2 = Linear(7, 8)
-        MergeLinear(l1, l2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,7 +38,7 @@ def test_canonicalize_init_func():
     assert resolve_init_func("xavier_uniform")(k, (2, 2)).shape == (2, 2)
 
     assert isinstance(resolve_init_func(jax.nn.initializers.he_normal()), jtu.Partial)
-    assert isinstance(resolve_init_func(None), type(None))
+    assert isinstance(resolve_init_func(None), jtu.Partial)
 
     with pytest.raises(ValueError):
         resolve_init_func("invalid")


### PR DESCRIPTION
- add batch norm , norm layers init func additions
- add `tree_evaluation` to return a tree with layers modified to operate during eval. also enable `tree_evaluation.def_evaluation` to determine the evaluation rule by dispatch.
- add `tree_state` to return a tree with state corresponds to layer (if exists), and defines `tree_state.def_state` to define state rules for layers by dispatch.