### PR TITLE
add weight norm wrapper

### DIFF
--- a/docs/API/normalization.rst
+++ b/docs/API/normalization.rst
@@ -6,3 +6,4 @@ Normalization
 .. autoclass:: InstanceNorm
 .. autoclass:: GroupNorm
 .. autoclass:: BatchNorm
+.. autoclass:: WeightNormWrapper

--- a/docs/API/normalization.rst
+++ b/docs/API/normalization.rst
@@ -6,4 +6,4 @@ Normalization
 .. autoclass:: InstanceNorm
 .. autoclass:: GroupNorm
 .. autoclass:: BatchNorm
-.. autoclass:: WeightNormWrapper
+.. autofunction:: weight_norm

--- a/serket/_src/nn/normalization.py
+++ b/serket/_src/nn/normalization.py
@@ -764,17 +764,6 @@ def weight_norm(
         eps: the epsilon value to be added to the denominator. defaults to 1e-12.
 
     Example:
-        >>> import jax.numpy as jnp
-        >>> import jax.random as jr
-        >>> import serket as sk
-        >>> linear = sk.nn.Linear(2, 4, key=jr.PRNGKey(0))
-        >>> # apply weight normalization to the `weight` leaf
-        >>> linear = linear.at["weight"].apply(sk.nn.weight_norm)
-        >>> x = jnp.ones((1, 2)) + 0.0
-        >>> print(linear(x))
-        [[ 1.1072588  0.8549536 -1.3897915 -1.1090417]]
-
-    Example:
         Normalize ``weight`` arrays of two-layer linear network but not ``bias``
 
         >>> import jax

--- a/serket/_src/nn/normalization.py
+++ b/serket/_src/nn/normalization.py
@@ -767,10 +767,10 @@ class WeightNormWrapper(sk.TreeClass):
         >>> import serket as sk
         >>> linear = sk.nn.Linear(2, 4, key=jr.PRNGKey(0))
         >>> mask = linear.at["weight"].set(True)
-        >>> linear = sk.nn.WeightNorm(linear, mask)
+        >>> linear = sk.nn.WeightNormWrapper(linear, mask)
         >>> x = jnp.ones((1, 2)) + 0.0
-        >>> linear(x)
-        [[ 1.1072401  0.8549473 -1.389786  -1.1090337]]
+        >>> print(linear(x))
+        [[ 1.1072588  0.8549536 -1.3897915 -1.1090417]]
     """
 
     def __init__(self, wrapped, mask, axis: int = -1, eps: float = 1e-12):

--- a/serket/_src/nn/normalization.py
+++ b/serket/_src/nn/normalization.py
@@ -774,7 +774,7 @@ def weight_norm(
         ...         k1, k2 = jax.random.split(key)
         ...         self.l1 = sk.nn.Linear(2, 4, key=k1)
         ...         self.l2 = sk.nn.Linear(4, 2, key=k2)
-        >>>     def __call__(self, inputs: jax.Array) -> jax.Array:
+        ...     def __call__(self, inputs: jax.Array) -> jax.Array:
         ...         # `...` selects all the first level nodes of `Net` (e.g. `l1`, `l2`)
         ...         # then the `weight` attribute of each layer at the second level
         ...         self = self.at[...]["weight"].apply(sk.nn.weight_norm)

--- a/serket/nn/__init__.py
+++ b/serket/nn/__init__.py
@@ -99,7 +99,13 @@ from serket._src.nn.dropout import (
     random_cutout_nd,
 )
 from serket._src.nn.linear import FNN, MLP, Embedding, GeneralLinear, Identity, Linear
-from serket._src.nn.normalization import BatchNorm, GroupNorm, InstanceNorm, LayerNorm
+from serket._src.nn.normalization import (
+    BatchNorm,
+    GroupNorm,
+    InstanceNorm,
+    LayerNorm,
+    WeightNormWrapper,
+)
 from serket._src.nn.pooling import (
     AdaptiveAvgPool1D,
     AdaptiveAvgPool2D,
@@ -271,6 +277,7 @@ __all__ = [
     "GroupNorm",
     "InstanceNorm",
     "LayerNorm",
+    "WeightNormWrapper",
     # pooling
     "AdaptiveAvgPool1D",
     "AdaptiveAvgPool2D",

--- a/serket/nn/__init__.py
+++ b/serket/nn/__init__.py
@@ -104,7 +104,7 @@ from serket._src.nn.normalization import (
     GroupNorm,
     InstanceNorm,
     LayerNorm,
-    WeightNormWrapper,
+    weight_norm,
 )
 from serket._src.nn.pooling import (
     AdaptiveAvgPool1D,
@@ -277,7 +277,7 @@ __all__ = [
     "GroupNorm",
     "InstanceNorm",
     "LayerNorm",
-    "WeightNormWrapper",
+    "weight_norm",
     # pooling
     "AdaptiveAvgPool1D",
     "AdaptiveAvgPool2D",

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -271,3 +271,18 @@ def test_batchnorm(axis, axis_name):
     in_axes = (0, None)
     x_sk, _ = jax.vmap(bn_sk_eval, in_axes, axis_name=axis_name)(x_sk, state)
     npt.assert_allclose(x_keras, x_sk, rtol=1e-4)
+
+
+def test_weight_norm_wrapper():
+    weight: jax.Array = jnp.array(
+        [
+            [-1.2662824, 0.6269297, 0.35720623, 0.04510251],
+            [0.557601, 0.11622565, -0.27115023, -0.19996592],
+        ],
+    )
+    linear = sk.nn.Linear(2, 4, key=jax.random.PRNGKey(0))
+    linear = linear.at["weight"].set(weight)
+    linear = sk.nn.WeightNormWrapper(linear, linear.at["weight"].set(True), axis=-1)
+    true = jnp.array([[-0.51219565, 1.1655288, 0.19189113, -0.7554708]])
+    pred = linear(jnp.ones((1, 2)))
+    npt.assert_allclose(true, pred, atol=1e-5)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -281,8 +281,7 @@ def test_weight_norm_wrapper():
         ],
     )
     linear = sk.nn.Linear(2, 4, key=jax.random.PRNGKey(0))
-    linear = linear.at["weight"].set(weight)
-    linear = sk.nn.WeightNormWrapper(linear, linear.at["weight"].set(True), axis=-1)
+    linear = linear.at["weight"].set(sk.nn.weight_norm(weight))
     true = jnp.array([[-0.51219565, 1.1655288, 0.19189113, -0.7554708]])
     pred = linear(jnp.ones((1, 2)))
     npt.assert_allclose(true, pred, atol=1e-5)


### PR DESCRIPTION
Add `weight_norm` function, should be used with `AtIndexer`

```python
>>> import jax
>>> import jax.numpy as jnp
>>> import serket as sk
>>> class Net(sk.TreeClass):
...     def __init__(self, *, key: jax.Array):
...         k1, k2 = jax.random.split(key)
...         self.l1 = sk.nn.Linear(2, 4, key=k1)
...         self.l2 = sk.nn.Linear(4, 2, key=k2)
...     def __call__(self, inputs: jax.Array) -> jax.Array:
...         # `...` selects all the first level nodes of `Net` (e.g. `l1`, `l2`)
...         # then the `weight` attribute of each layer at the second level
...         self = self.at[...]["weight"].apply(sk.nn.weight_norm)
...         return self.l2(self.l1(inputs))
```